### PR TITLE
fix: ignore index.html files inside project public dir

### DIFF
--- a/packages/ladle/lib/cli/metro-dev.js
+++ b/packages/ladle/lib/cli/metro-dev.js
@@ -96,7 +96,7 @@ const metroDev = async (ladleConfig, configFolder) => {
     host: hostname,
     unstable_extraMiddleware: [
       // Serve static assets from project's /public dir
-      express.static(projectPublicDir),
+      express.static(projectPublicDir, { index: false }),
 
       // Serve Ladle specific stuff
       ladleMiddleware,


### PR DESCRIPTION
Static middleware was picking up "index.html" file inside user's public directory which was breaking the Ladle loading process. This PR make the middleware ignore the index.html so our http server can server our internal index.html instead.